### PR TITLE
fix(auth): separate email and password validation in signUp

### DIFF
--- a/lib/feat/core/utils/constants/app_texts.dart
+++ b/lib/feat/core/utils/constants/app_texts.dart
@@ -36,7 +36,9 @@ class AppTexts {
 
   // auth cubit texts
   static const String reqresEmail = 'eve.holt@reqres.in';
+  static const String reqresPassword = 'pistol';
   static const String emailNotRegistered = 'Email is not registered';
+  static const String wrongPassword = 'Wrong password';
   static const String signUpSuccess = 'Sign up successful:';
   static const String anErrorOccurred = 'An error occurred : ';
 }

--- a/lib/feat/presentation/cubit/auth/auth_cubit.dart
+++ b/lib/feat/presentation/cubit/auth/auth_cubit.dart
@@ -4,10 +4,8 @@ import 'package:recipe_app_flutter/feat/core/duration/app_duration.dart';
 import 'package:recipe_app_flutter/feat/core/utils/constants/app_texts.dart';
 import 'package:recipe_app_flutter/feat/core/widgets/navigation_helper/navigation_helper.dart';
 import 'package:recipe_app_flutter/feat/data/model/auth/auth_register_model.dart';
-
 import 'package:recipe_app_flutter/feat/data/service/auth/user_service.dart';
 import 'package:recipe_app_flutter/feat/presentation/pages/home/page/home_page.dart';
-
 part 'auth_state.dart';
 
 class AuthCubit extends Cubit<AuthState> {
@@ -48,11 +46,24 @@ class AuthCubit extends Cubit<AuthState> {
     emit(AuthLoading());
     try {
       final email = emailController.text.trim();
+      final password = passwordController.text.trim();
+
       if (email != AppTexts.reqresEmail) {
         emit(AuthError(AppTexts.emailNotRegistered));
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(AppTexts.emailNotRegistered),
+            backgroundColor: Colors.red,
+          ),
+        );
+        return;
+      }
+
+      if (password != AppTexts.reqresPassword) {
+        emit(AuthError(AppTexts.wrongPassword));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppTexts.wrongPassword),
             backgroundColor: Colors.red,
           ),
         );


### PR DESCRIPTION
Previously, entering a correct email with wrong password triggered "email not registered" error. Now, email and password are validated independently, showing the correct error message.